### PR TITLE
Ship pep440_rs types in python bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "pep440_rs"
 version = "0.2.0"
-source = "git+https://github.com/konstin/pep440-rs#767ead05655de2a3cc13e613268708fd12044ff8"
+source = "git+https://github.com/konstin/pep440-rs#44850cbe447b2203230d1f0e7a3b6d4711f73c17"
 dependencies = [
  "lazy_static",
  "pyo3",
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08de71aa0d6e348f070457f85af8bd566e2bc452156a423ddf22861b3a953fae"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
 dependencies = [
  "indexmap",
  "serde",
@@ -717,9 +717,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
 ]

--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,7 @@ assert requests.extras == ["security", "tests"]
 assert [str(i) for i in requests.version_or_url] == [">= 2.8.1", "== 2.8.*"]
 ```
 
+Python bindings are built with [maturin](https://github.com/PyO3/maturin), but you can also use the normal `pip install .`
 
 ## Markers
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,23 +217,6 @@ impl Requirement {
         }
     }
 
-    /// TODO: A less hacky solution that handles all cases and has the pep440 str updates
-    #[getter]
-    fn version_specifier_str(&self, py: Python<'_>) -> PyResult<PyObject> {
-        match &self.version_or_url {
-            None => Ok(py.None()),
-            Some(VersionOrUrl::VersionSpecifier(version_specifier)) => Ok(version_specifier
-                .iter()
-                .map(|x| x.to_string())
-                .collect::<Vec<String>>()
-                .into_py(py)),
-            Some(VersionOrUrl::Url(_url)) => Err(PyValueError::new_err(format!(
-                "Expected version specifier, found url for {}",
-                self.name
-            ))),
-        }
-    }
-
     fn __str__(&self) -> String {
         self.to_string()
     }

--- a/test/test_pep508.py
+++ b/test/test_pep508.py
@@ -1,5 +1,5 @@
 import pytest
-from pep508_rs import Requirement, MarkerEnvironment, Pep508Error
+from pep508_rs import Requirement, MarkerEnvironment, Pep508Error, VersionSpecifier
 
 
 def test_pep508():
@@ -15,7 +15,10 @@ def test_pep508():
     )
     assert requests.name == "requests"
     assert requests.extras == ["security", "tests"]
-    assert [str(i) for i in requests.version_or_url] == [">= 2.8.1", "== 2.8.*"]
+    assert requests.version_or_url == [
+        VersionSpecifier(">= 2.8.1"),
+        VersionSpecifier("== 2.8.*"),
+    ]
 
 
 def test_marker():


### PR DESCRIPTION
This adds `Version` and `VersionSpecifier` to `pep508_rs` in python. That is because in the python bindings `pep440_rs.Version("1.2.3") != pep508_rs.Requirement("numpy==1.2.3").version_or_url` as the `Version`s come from two different binaries in two different python packages and can therefore never be equal.

This came up in downstream code.