### PR TITLE
Add an `evaluate_extras` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,10 +193,10 @@ impl Serialize for Requirement {
     }
 }
 
-#[cfg(feature = "pyo3")]
-#[pymethods]
+#[cfg_attr(feature = "pyo3", pymethods)]
 impl Requirement {
     /// Parses a PEP 440 string
+    #[cfg(feature = "pyo3")]
     #[new]
     pub fn py_new(requirement: &str) -> PyResult<Self> {
         Self::from_str(requirement).map_err(|err| PyPep508Error::new_err(err.to_string()))
@@ -209,6 +209,19 @@ impl Requirement {
                 env,
                 &extras.iter().map(String::as_str).collect::<Vec<&str>>(),
             )
+        } else {
+            true
+        }
+    }
+
+    /// Returns whether the requirement would be satisfied, independent of environment markers
+    ///
+    /// Note that unlike [evaluate] this does not perform any checks for bogus expressions but will
+    /// simply return true. As caller you should separately perform a check with the an environment
+    //  and forward all warnings.
+    pub fn evaluate_extras(&self, extras: Vec<String>) -> bool {
+        if let Some(marker) = &self.marker {
+            marker.evaluate_extras(&extras.iter().map(String::as_str).collect::<Vec<&str>>())
         } else {
             true
         }
@@ -230,6 +243,7 @@ impl Requirement {
         }
     }
 
+    #[cfg(feature = "pyo3")]
     #[getter]
     fn version_or_url(&self, py: Python<'_>) -> PyObject {
         match &self.version_or_url {
@@ -243,14 +257,17 @@ impl Requirement {
         }
     }
 
+    #[cfg(feature = "pyo3")]
     fn __str__(&self) -> String {
         self.to_string()
     }
 
+    #[cfg(feature = "pyo3")]
     fn __repr__(&self) -> String {
         format!(r#""{}""#, self)
     }
 
+    #[cfg(feature = "pyo3")]
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
         let err = PyNotImplementedError::new_err("Requirement only supports equality comparisons");
         match op {
@@ -263,6 +280,7 @@ impl Requirement {
         }
     }
 
+    #[cfg(feature = "pyo3")]
     fn __hash__(&self) -> u64 {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use pyo3::{
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "pyo3")]
 use std::collections::hash_map::DefaultHasher;
+use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 #[cfg(feature = "pyo3")]
 use std::hash::{Hash, Hasher};
@@ -220,9 +221,9 @@ impl Requirement {
     /// Note that unlike [Self::evaluate_markers] this does not perform any checks for bogus
     /// expressions but will simply return true. As caller you should separately perform a check
     /// with an environment and forward all warnings.
-    pub fn evaluate_extras(&self, extras: Vec<String>) -> bool {
+    pub fn evaluate_extras(&self, extras: HashSet<String>) -> bool {
         if let Some(marker) = &self.marker {
-            marker.evaluate_extras(&extras.iter().map(String::as_str).collect::<Vec<&str>>())
+            marker.evaluate_extras(&extras)
         } else {
             true
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,11 +214,12 @@ impl Requirement {
         }
     }
 
-    /// Returns whether the requirement would be satisfied, independent of environment markers
+    /// Returns whether the requirement would be satisfied, independent of environment markers, i.e.
+    /// if there is potentially an environment that could activate this requirement.
     ///
-    /// Note that unlike [evaluate] this does not perform any checks for bogus expressions but will
-    /// simply return true. As caller you should separately perform a check with the an environment
-    //  and forward all warnings.
+    /// Note that unlike [Self::evaluate_markers] this does not perform any checks for bogus
+    /// expressions but will simply return true. As caller you should separately perform a check
+    /// with an environment and forward all warnings.
     pub fn evaluate_extras(&self, extras: Vec<String>) -> bool {
         if let Some(marker) = &self.marker {
             marker.evaluate_extras(&extras.iter().map(String::as_str).collect::<Vec<&str>>())

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -657,8 +657,8 @@ impl MarkerExpression {
     /// Checks if the current expression is a `extra == '...'` or a `'...' == extra` and evaluates
     /// those for the given set of extras.
     ///
-    /// Note that unlike [evaluate] this does not perform any checks for bogus expressions but will
-    /// simply return true.
+    /// Note that unlike [Self::evaluate] this does not perform any checks for bogus expressions but
+    /// will simply return true.
     fn evaluate_extras(&self, extras: &[&str]) -> bool {
         match (&self.l_value, &self.operator, &self.r_value) {
             // `extra == '...'`
@@ -822,10 +822,11 @@ impl MarkerTree {
     }
 
     /// Checks if the requirement should be activated with the given set of extras without
-    /// evaluating the remaining environment markers
+    /// evaluating the remaining environment markers, i.e. if there is potentially an environment
+    /// that could activate this requirement.
     ///
-    /// Note that unlike [evaluate] this does not perform any checks for bogus expressions but will
-    /// simply return true. As caller you should separately perform a check with the an environment
+    /// Note that unlike [Self::evaluate] this does not perform any checks for bogus expressions but
+    /// will simply return true. As caller you should separately perform a check with an environment
     /// and forward all warnings.
     pub fn evaluate_extras(&self, extras: &[&str]) -> bool {
         match self {


### PR DESCRIPTION
`evaluate_extras` checks if the requirement should be activated with the given set of extras without evaluating the remaining environment markers, without performing any validation. we need this during dependency resolution because we want to resolve to a consistent set of dependencies that can be installed on any platform (by filtering this resolution by the current environment), but only resolve those optional dependencies that are or can actually required by extras.