### PR TITLE
Evaluate python version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 [[package]]
 name = "pep440_rs"
 version = "0.2.0"
-source = "git+https://github.com/konstin/pep440-rs#0e9d26526234a6615b1316d6ef7ba79ed6beac09"
+source = "git+https://github.com/konstin/pep440-rs#7bcbbc2ae7159d1032e78a1d98d2c50a85697155"
 dependencies = [
  "lazy_static",
  "pyo3",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,7 +785,9 @@ fn parse(chars: &mut CharIter) -> Result<Requirement, Pep508Error> {
 pub fn python_module(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     // Allowed to fail if we embed this module in another
     #[allow(unused_must_use)]
-    pyo3_log::try_init();
+    {
+        pyo3_log::try_init();
+    }
 
     m.add_class::<Version>()?;
     m.add_class::<VersionSpecifier>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,7 @@ pub mod modern;
 pub use marker::{
     MarkerEnvironment, MarkerExpression, MarkerOperator, MarkerTree, MarkerValue, MarkerWarningKind,
 };
-#[cfg(feature = "pyo3")]
-use pep440_rs::Version;
-use pep440_rs::{VersionSpecifier, VersionSpecifiers};
+use pep440_rs::{Version, VersionSpecifier, VersionSpecifiers};
 #[cfg(feature = "pyo3")]
 use pyo3::{
     basic::CompareOp, create_exception, exceptions::PyNotImplementedError, pyclass, pymethods,
@@ -221,9 +219,13 @@ impl Requirement {
     /// Note that unlike [Self::evaluate_markers] this does not perform any checks for bogus
     /// expressions but will simply return true. As caller you should separately perform a check
     /// with an environment and forward all warnings.
-    pub fn evaluate_extras(&self, extras: HashSet<String>) -> bool {
+    pub fn evaluate_extras_and_python_version(
+        &self,
+        extras: HashSet<String>,
+        python_versions: Vec<Version>,
+    ) -> bool {
         if let Some(marker) = &self.marker {
-            marker.evaluate_extras(&extras)
+            marker.evaluate_extras_and_python_version(&extras, &python_versions)
         } else {
             true
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -783,8 +783,9 @@ fn parse(chars: &mut CharIter) -> Result<Requirement, Pep508Error> {
 #[pymodule]
 #[pyo3(name = "pep508_rs")]
 pub fn python_module(py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    #[cfg(feature = "pyo3")]
-    pyo3_log::init();
+    // Allowed to fail if we embed this module in another
+    #[allow(unused_must_use)]
+    pyo3_log::try_init();
 
     m.add_class::<Version>()?;
     m.add_class::<VersionSpecifier>()?;

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -667,20 +667,23 @@ impl MarkerExpression {
     /// will simply return true.
     ///
     /// ```rust
-    /// use std::collections::HashSet;
-    /// use std::str::FromStr;
-    /// use pep508_rs::MarkerTree;
-    /// use pep440_rs::Version;
+    /// # use std::collections::HashSet;
+    /// # use std::str::FromStr;
+    /// # use pep508_rs::MarkerTree;
+    /// # use pep440_rs::Version;
     ///
-    /// let marker_tree = MarkerTree::from_str(r#"("linux" in sys_platform) and extra == 'day'"#).unwrap();
+    /// # fn main() -> anyhow::Result<()> {
+    /// let marker_tree = MarkerTree::from_str(r#"("linux" in sys_platform) and extra == 'day'"#)?;
     /// let versions: Vec<Version> = (8..12).map(|minor| Version::from_release(vec![3, minor])).collect();
     /// assert!(marker_tree.evaluate_extras_and_python_version(&["day".to_string()].into(), &versions));
     /// assert!(!marker_tree.evaluate_extras_and_python_version(&["night".to_string()].into(), &versions));
     ///
-    /// let marker_tree = MarkerTree::from_str(r#"extra == 'day' and python_version < '3.11' and '3.10' <= python_version"#).unwrap();
+    /// let marker_tree = MarkerTree::from_str(r#"extra == 'day' and python_version < '3.11' and '3.10' <= python_version"#)?;
     /// assert!(!marker_tree.evaluate_extras_and_python_version(&["day".to_string()].into(), &vec![Version::from_release(vec![3, 9])]));
     /// assert!(marker_tree.evaluate_extras_and_python_version(&["day".to_string()].into(), &vec![Version::from_release(vec![3, 10])]));
     /// assert!(!marker_tree.evaluate_extras_and_python_version(&["day".to_string()].into(), &vec![Version::from_release(vec![3, 11])]));
+    /// # Ok(())
+    /// # }
     /// ```
     fn evaluate_extras_and_python_version(
         &self,
@@ -709,8 +712,6 @@ impl MarkerExpression {
                     // operator and right hand side make the specifier
                     let specifier = VersionSpecifier::new(operator, r_version, r_star).ok()?;
 
-                    // We're passing a lot of versions here, e.g. 3.8 .. 3.100, but since we're
-                    // passing them in order it is expected that we either match early or not at all
                     let compatible = python_versions
                         .iter()
                         .any(|l_version| specifier.contains(l_version));
@@ -730,8 +731,6 @@ impl MarkerExpression {
                     let l_version = Version::from_str(l_string).ok()?;
                     let operator = operator.to_pep440_operator()?;
 
-                    // We're passing a lot of versions here, e.g. 3.8 .. 3.100, but since we're
-                    // passing them in order it is expected that we either match early or not at all
                     let compatible = python_versions.iter().any(|r_version| {
                         // operator and right hand side make the specifier and in this case the
                         // right hand is `python_version` so changes every iteration

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -655,8 +655,13 @@ impl MarkerExpression {
         }
     }
 
-    /// Checks if the current expression is a `extra == '...'` or a `'...' == extra` and evaluates
-    /// those for the given set of extras.
+    /// Evaluates only the extras and python version part of the markers. We use this during
+    /// dependency resolution when we want to have packages for all possible environments but
+    /// already know the extras and the possible python versions (from `requires-python`)
+    ///
+    /// This considers only expression in the from `extra == '...'`, `'...' == extra`,
+    /// `python_version <pep PEP 440 operator> '...'` and
+    /// `'...' <pep PEP 440 operator>  python_version`.
     ///
     /// Note that unlike [Self::evaluate] this does not perform any checks for bogus expressions but
     /// will simply return true.
@@ -892,9 +897,10 @@ impl MarkerTree {
         }
     }
 
-    /// Checks if the requirement should be activated with the given set of extras without
-    /// evaluating the remaining environment markers, i.e. if there is potentially an environment
-    /// that could activate this requirement.
+    /// Checks if the requirement should be activated with the given set of active extras and a set
+    /// of possible python versions (from `requires-python`) without evaluating the remaining
+    /// environment markers, i.e. if there is potentially an environment that could activate this
+    /// requirement.
     ///
     /// Note that unlike [Self::evaluate] this does not perform any checks for bogus expressions but
     /// will simply return true. As caller you should separately perform a check with an environment

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -669,10 +669,10 @@ impl MarkerExpression {
     /// ```rust
     /// # use std::collections::HashSet;
     /// # use std::str::FromStr;
-    /// # use pep508_rs::MarkerTree;
+    /// # use pep508_rs::{MarkerTree, Pep508Error};
     /// # use pep440_rs::Version;
     ///
-    /// # fn main() -> anyhow::Result<()> {
+    /// # fn main() -> Result<(), Pep508Error> {
     /// let marker_tree = MarkerTree::from_str(r#"("linux" in sys_platform) and extra == 'day'"#)?;
     /// let versions: Vec<Version> = (8..12).map(|minor| Version::from_release(vec![3, minor])).collect();
     /// assert!(marker_tree.evaluate_extras_and_python_version(&["day".to_string()].into(), &versions));


### PR DESCRIPTION
In the resolver, we want to only consider those requirements of a package that match the selected extras, i.e. only pull the actually used optional dependencies into the resolution, and that fulfill the selected python version ranges, which is important because you sometime see incompatible version ranges used for old and new python versions. Meanwhile, we want to ignore platform specific markers to get a platform independent resolution.

Previously, we had the requirements filtered to selected extras, this extends this to the selected python version. The strategy is to pass a list of python versions that fulfill `requires-python` from pyproject.toml in since computing PEP 440 overlapping version ranges would be overly complicated.