### PR TITLE
feat: add origin to pep508 type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 
 #![warn(missing_docs)]
 
+use origin::RequirementOrigin;
 #[cfg(feature = "pyo3")]
 use pep440_rs::PyVersion;
 use pep440_rs::{Version, VersionSpecifier, VersionSpecifiers};
@@ -46,6 +47,7 @@ pub use verbatim_url::{split_scheme, VerbatimUrl};
 
 mod marker;
 mod normalize;
+mod origin;
 mod verbatim_url;
 
 /// Error with a span attached. Not that those aren't `String` but `Vec<char>` indices.
@@ -137,6 +139,19 @@ pub struct Requirement {
     /// `requests [security,tests] >= 2.8.1, == 2.8.* ; python_version > "3.8"`.
     /// Those are a nested and/or tree
     pub marker: Option<MarkerTree>,
+    /// The source file containing the requirement.
+    pub origin: Option<RequirementOrigin>,
+}
+
+impl Requirement {
+    /// Set the source file containing the requirement.
+    #[must_use]
+    pub fn with_origin(self, origin: RequirementOrigin) -> Self {
+        Self {
+            origin: Some(origin),
+            ..self
+        }
+    }
 }
 
 impl Display for Requirement {
@@ -993,6 +1008,7 @@ fn parse(cursor: &mut Cursor, working_dir: Option<&Path>) -> Result<Requirement,
         extras,
         version_or_url: requirement_kind,
         marker,
+        origin: None,
     })
 }
 
@@ -1126,6 +1142,7 @@ mod tests {
                 operator: MarkerOperator::LessThan,
                 r_value: MarkerValue::QuotedString("2.7".to_string()),
             })),
+            origin: None,
         };
         assert_eq!(requests, expected);
     }
@@ -1291,6 +1308,7 @@ mod tests {
             extras: vec![],
             marker: None,
             version_or_url: Some(VersionOrUrl::Url(VerbatimUrl::from_str(url).unwrap())),
+            origin: None,
         };
         assert_eq!(pip_url, expected);
     }

--- a/src/origin.rs
+++ b/src/origin.rs
@@ -1,0 +1,22 @@
+use std::path::{Path, PathBuf};
+
+use crate::normalize::PackageName;
+
+/// The origin of a dependency, e.g., a `-r requirements.txt` file.
+#[derive(Hash, Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub enum RequirementOrigin {
+    /// The requirement was provided via a standalone file (e.g., a `requirements.txt` file).
+    File(PathBuf),
+    /// The requirement was provided via a local project (e.g., a `pyproject.toml` file).
+    Project(PathBuf, PackageName),
+}
+
+impl RequirementOrigin {
+    /// Returns the path of the requirement origin.
+    pub fn path(&self) -> &Path {
+        match self {
+            RequirementOrigin::File(path) => path.as_path(),
+            RequirementOrigin::Project(path, _) => path.as_path(),
+        }
+    }
+}


### PR DESCRIPTION
This PR add the origin field to `pep508_rs` to make it compatible with the internal crate used by uv: https://github.com/astral-sh/uv/tree/main/crates/pep508-rs

We need this because we use uv in pixi which makes use of: https://github.com/mamba-org/rattler because we need rattler to be published to crates.io, we can only make use of the published `pep508_rs` version. Therefore we patch `pep404_rs` and `pep508_rs` to the uv version in pixi. Adding this PR should make this possible again, given the latest additions to the uv crate.

Thanks!