### PR TITLE
refactor: remove derivative dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,17 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,7 +195,6 @@ dependencies = [
 name = "pep508_rs"
 version = "0.6.1"
 dependencies = [
- "derivative",
  "indoc",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ name = "pep508_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-derivative = "2.2.0"
 once_cell = "1.19.0"
 pep440_rs = "0.6.5"
 pyo3 = { version = "0.22", optional = true, features = ["abi3", "extension-module"] }

--- a/src/verbatim_url.rs
+++ b/src/verbatim_url.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::fmt::Debug;
+use std::hash::Hash;
 use std::ops::Deref;
 use std::path::{Component, Path, PathBuf};
 
@@ -8,8 +9,7 @@ use regex::Regex;
 use url::Url;
 
 /// A wrapper around [`Url`] that preserves the original string.
-#[derive(Debug, Clone, Eq, derivative::Derivative)]
-#[derivative(PartialEq, Hash)]
+#[derive(Debug, Clone, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerbatimUrl {
     /// The parsed URL.
@@ -22,9 +22,19 @@ pub struct VerbatimUrl {
     )]
     url: Url,
     /// The URL as it was provided by the user.
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Hash = "ignore")]
     given: Option<String>,
+}
+
+impl Hash for VerbatimUrl {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.url.hash(state);
+    }
+}
+
+impl PartialEq for VerbatimUrl {
+    fn eq(&self, other: &Self) -> bool {
+        self.url == other.url
+    }
 }
 
 impl VerbatimUrl {


### PR DESCRIPTION
This removes the `derivative` dependency which [seems to be unmaintained](https://github.com/mcarton/rust-derivative/issues/117) and depends on old versions of some crates, especially `syn`. 

I could also replace it with another crate like `educe` or `derive-where` but the implementation seems simple enough.