### PR TITLE
fix: return an error instead of panic when package name is invalid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,8 +473,12 @@ fn parse_name<T: Pep508Url>(cursor: &mut Cursor) -> Result<PackageName, Pep508Er
                 }
             }
             Some(_) | None => {
-                return Ok(PackageName::new(name)
-                    .expect("`PackageName` validation should match PEP 508 parsing"));
+                return PackageName::new(name).map_err(|e| Pep508Error {
+                    message: Pep508ErrorSource::String(e.to_string()),
+                    start: 0,
+                    len: 1,
+                    input: cursor.to_string(),
+                });
             }
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -698,6 +698,18 @@ fn error_random_char() {
 }
 
 #[test]
+fn error_invalid_package_name() {
+    assert_snapshot!(
+        parse_pep508_err("1. >= 1"),
+        @r##"
+    Not a valid package or extra name: "1.". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+    1. >= 1
+    ^
+    "##
+    );
+}
+
+#[test]
 #[cfg(feature = "non-pep508-extensions")]
 fn error_invalid_extra_unnamed_url() {
     assert_snapshot!(


### PR DESCRIPTION
thanks for the nice crate, we use it in one of our projects and recently we failed to parse a file, which had an invalid package name.